### PR TITLE
Add suport for anonymous schema inside allOf attribute

### DIFF
--- a/packages/core/src/lib/generators/Common.ts
+++ b/packages/core/src/lib/generators/Common.ts
@@ -83,25 +83,22 @@ export const renderProperties =
         return isEnumDeclaration
           ? schema.enum.map((e) => `${e} = "${e}"`).join(",\n\t")
           : schema.enum.map((e) => `"${e}"`).join(" | ");
-      } else if (schema.allOf && schema.allOf[0]) {
-        const allOf = schema.allOf[0];
-        if (allOf.$ref) {
-          const typeName = getTypeNameFromRef(allOf.$ref)!;
-          const tt = swagger.components.schemas[typeName]!;
-          if (schema.type === "object") {
-            return renderProperties(swagger)(tt);
-          } else if (tt.type === "object") {
-            return typeName!;
-          }
-          return `typeof ${typeName}`;
-        }
-        if (allOf.enum) {
-          return allOf.enum.map((e) => e).join(" | ");
-        }
-        if (allOf.type === "object") {
-          return "any";
-        }
-        return "any";
+      } else if (schema.allOf) {
+        return schema.allOf
+          .map((x) => {
+            if (x.$ref) {
+              const typeName = getTypeNameFromRef(x.$ref)!;
+              const tt = swagger.components.schemas[typeName]!;
+              if (schema.type === "object") {
+                return renderProperties(swagger)(tt);
+              } else if (tt.type === "object") {
+                return typeName!;
+              }
+              return `typeof ${typeName}`;
+            }
+            return renderProperties(swagger)(x);
+          })
+          .join("\n\t");
       } else if (schema.type) {
         switch (schema.type) {
           case "integer":

--- a/packages/core/src/tests/__snapshots__/generate_allof_anonymous_schema.ts
+++ b/packages/core/src/tests/__snapshots__/generate_allof_anonymous_schema.ts
@@ -1,0 +1,400 @@
+/* eslint-disable */
+// THIS FILE WAS GENERATED
+// ALL CHANGES WILL BE OVERWRITTEN
+
+// INFRASTRUCTURE START
+  type StandardError = globalThis.Error;
+  type Error500s = 501 | 502 | 503 | 504 | 505 | 506 | 507 | 508 | 510 | 511;
+  type ErrorStatuses = 0 | Error500s;
+  export type ErrorResponse = FetchResponse<unknown, ErrorStatuses>;
+
+  export type FetchResponseOfError = {
+    data: null;
+    error: StandardError;
+    status: ErrorStatuses;
+    args: any;
+  };
+
+  export type FetchResponseOfSuccess<TData, TStatus extends number = 0> = 
+  {
+    data: TData;
+    error: null;
+    status: TStatus;
+    args: any;
+    responseHeaders: Headers;
+  };
+
+  export type FetchResponse<TData, TStatus extends number = 0> = 
+    TStatus extends ErrorStatuses ? FetchResponseOfError: FetchResponseOfSuccess<TData, TStatus>;
+
+  type TerminateRequest = null;
+  type TerminateResponse = null;
+
+  type Configuration = {
+    apiUrl: string | (() => string);
+    jwtKey: string | undefined | (() => string | null | undefined);
+    requestMiddlewares?: Array<{
+      name: string;
+      fn: (request: FetchArgs) => FetchArgs | TerminateRequest;
+    }>;
+    responseMiddlewares?: Array<{
+      name: string;
+      fn: (
+        response: FetchResponse<unknown, any>
+      ) => FetchResponse<unknown, any> | TerminateResponse;
+    }>;
+  };
+
+  let CONFIG: Configuration = {
+    apiUrl: () => "",
+    jwtKey: undefined,
+    requestMiddlewares: [],
+    responseMiddlewares: [],
+  };
+
+  export function configureApiCalls(configuration: Configuration) {
+    CONFIG = {
+      ...CONFIG,
+      ...configuration,
+      requestMiddlewares: [
+        ...(CONFIG.requestMiddlewares || []),
+        ...(configuration.requestMiddlewares || []),
+      ],
+      responseMiddlewares: [
+        ...(CONFIG.responseMiddlewares || []),
+        ...(configuration.responseMiddlewares || []),
+      ],
+    };
+  }
+
+  function getApiUrl() {
+    if (typeof CONFIG.apiUrl === "function") {
+      return CONFIG.apiUrl();
+    }
+    return CONFIG.apiUrl;
+  }
+
+  type Termination = {
+    termination: {
+      name: string;
+    };
+  };
+
+  function processRequestWithMiddlewares(
+    request: FetchArgs
+  ): FetchArgs | Termination {
+    for (const middleware of CONFIG.requestMiddlewares || []) {
+      try {
+        const middlewareResponse = middleware.fn(request);
+        if (middlewareResponse === null) {
+          return { termination: { name: middleware.name } };
+        }
+        request = middlewareResponse;
+      } catch (e) {
+        console.error("Request middleware error", e);
+      }
+    }
+    return request;
+  }
+
+  function processResponseWithMiddlewares<T extends FetchResponse<unknown, any>>(
+    response: T
+  ): T | Termination {
+    for (const middleware of CONFIG.responseMiddlewares || []) {
+      try {
+        const middlewareResponse = middleware.fn(response);
+        if (middlewareResponse === null) {
+          return {
+            status: 0,
+            args: response.args,
+            data: null,
+            error: new Error(
+              `Response terminated by middleware: ${middleware.name}`
+            ),
+          } as FetchResponseOfError as unknown as T;
+        }
+        response = middlewareResponse as T;
+      } catch (e) {
+        console.error("Response middleware error", e);
+      }
+    }
+    return response;
+  }
+
+  type FetchOptions = {
+    method: string;
+    headers: Headers;
+    body?: any;
+    redirect: RequestRedirect;
+  };
+
+  type FetchArgs = {
+    url: string;
+    options: FetchOptions;
+  }
+
+  async function fetchJson<T extends FetchResponse<unknown, number>>(
+    args: FetchArgs
+  ): Promise<T> {
+    const errorResponse = (error: StandardError, status: number, args: any) => {
+      const errorResponse = {
+        status: status as ErrorStatuses,
+        args,
+        data: null,
+        error,
+      } satisfies FetchResponse<T>;
+
+      return processResponseWithMiddlewares(errorResponse) as unknown as T;
+    };
+
+    const errorStatus = (args: any) => {
+      const errorResponse = {
+        status: 0,
+        args,
+        data: null,
+        error: new Error("Network error"),
+      } as FetchResponse<T, Error500s>;
+
+      return processResponseWithMiddlewares(errorResponse) as unknown as T;
+    };
+
+    try {
+      const fetchRequest = processRequestWithMiddlewares(args);
+
+      if ("termination" in fetchRequest) {
+        const terminationResponse = {
+          status: 0,
+          args,
+          data: null,
+          error: new Error(
+            `Request terminated by middleware: ${fetchRequest.termination.name}`
+          ),
+        } as FetchResponse<T, Error500s>;
+
+        return processResponseWithMiddlewares(
+          terminationResponse
+        ) as unknown as T;
+      }
+
+      const fetchResponse: Response = await fetch(fetchRequest.url, fetchRequest.options);
+      const status = fetchResponse.status;
+      try {
+        const json = await fetchResponse.json();
+        const response = {
+          data: json,
+          status: fetchResponse.status,
+          args,
+          error: null,
+          responseHeaders: fetchResponse.headers,
+        };
+        return processResponseWithMiddlewares(response) as unknown as T;
+      } catch (error) {
+        return errorResponse(error as StandardError, status, args);
+      }
+    } catch {
+      return errorStatus(args);
+    }
+  }
+
+  function getToken(): string | null | undefined {
+    if (typeof CONFIG.jwtKey === "function") {
+      return CONFIG.jwtKey();
+    }
+
+    if (typeof CONFIG.jwtKey === "string") {
+      return localStorage.getItem(CONFIG.jwtKey);
+    }
+
+    return undefined;
+  }
+  
+  function updateHeaders(headers: Headers) {
+    if (!headers.has("Content-Type")) {
+      headers.append("Content-Type", "application/json");
+    }
+    const token = getToken();
+    if (!headers.has("Authorization") && token) {
+      headers.append("Authorization", token);
+    }
+  };
+
+function getQueryParamsString(paramsObject: ParamsObject = {}) {
+	const queryString = Object.entries(paramsObject)
+    .map(([key, value]) => {
+      if (Array.isArray(value)) {
+        return value
+          .map(val => `${encodeURIComponent(key)}=${encodeURIComponent(
+            val,
+          )}`)
+          .join('&');
+      }
+      // Handling non-array parameters
+      return value !== undefined && value !== null 
+        ? `${encodeURIComponent(key)}=${encodeURIComponent(value)}` 
+        : '';
+    })
+    .filter(part => part !== '')
+    .join("&");
+
+	return queryString.length > 0 ? `?${queryString}` : '';
+}
+
+function apiPost<TResponse extends FetchResponse<unknown, number>, TRequest>(
+  url: string,
+  request: TRequest,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  const raw = JSON.stringify(request);
+
+  updateHeaders(headers);
+
+  const requestOptions: FetchOptions = {
+    method: "POST",
+    headers,
+    body: raw,
+    redirect: "follow",
+  };
+
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+type ParamsObject = {
+  [key: string]: any;
+};
+
+function apiGet<TResponse extends FetchResponse<unknown, number>>(
+  url: string,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+  
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  const requestOptions: FetchOptions = {
+    method: "GET",
+    headers,
+    redirect: "follow",
+  };
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+function apiPut<TResponse extends FetchResponse<unknown, number>, TRequest>(
+  url: string,
+  request: TRequest,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+
+  const raw = JSON.stringify(request);
+
+  const requestOptions: FetchOptions = {
+    method: "PUT",
+    headers,
+    body: raw,
+    redirect: "follow",
+  };
+
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+function apiDelete<TResponse extends FetchResponse<unknown, number>>(
+  url: string,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+
+  const queryString = Object.entries(paramsObject)
+    .filter(([_, val]) => val !== undefined && val !== null)
+    .map(([key, val]) => `${key}=${val}`)
+    .join("&");
+  
+  const maybeQueryString = queryString.length > 0 ? `?${queryString}` : "";
+
+  const requestOptions: FetchOptions = {
+    method: "DELETE",
+    headers,
+    redirect: "follow",
+  };
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+function apiPatch<TResponse extends FetchResponse<unknown, number>, TRequest>(
+  url: string,
+  request: TRequest,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+
+  const raw = JSON.stringify(request);
+
+  const requestOptions: FetchOptions = {
+    method: "PATCH",
+    headers,
+    body: raw,
+    redirect: "follow",
+  };
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+// INFRASTRUCTURE END
+
+export type Pet = {
+	discriminator: string;
+};
+
+export type Dog = {
+	discriminator: string;
+	woof: boolean;
+};
+
+export type Cat = {
+	discriminator: string;
+	eat: boolean;
+	meow: boolean;
+};
+
+export type Cow = {
+	moo: boolean;
+	discriminator: string;
+};
+
+
+
+export type GetTestFetchResponse = 
+| FetchResponse<{status: string;
+	data?: Dog | Cat | Cow | null;}, 200> 
+| ErrorResponse;
+
+export const getTestPath = () => `/api/test`;
+
+export const getTest = (headers = new Headers()): 
+	Promise<GetTestFetchResponse> => {
+	return apiGet(`${getApiUrl()}${getTestPath()}`, headers, {}) as Promise<GetTestFetchResponse>;
+}

--- a/packages/core/src/tests/__snapshots__/generate_allof_anonymous_schema_angular.ts
+++ b/packages/core/src/tests/__snapshots__/generate_allof_anonymous_schema_angular.ts
@@ -1,0 +1,310 @@
+/* eslint-disable */
+// THIS FILE WAS GENERATED
+// ALL CHANGES WILL BE OVERWRITTEN
+
+// INFRASTRUCTURE START
+
+import { HttpClient, HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
+import { Observable, of, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+type FlattenableValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Date
+  | FlattenableValue[]
+  | {
+      [prop: string]: FlattenableValue;
+    };
+
+type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
+
+function flattenQueryParams(data: QueryParams) {
+  const params: Record<string, any> = {};
+  flatten(params, data, '');
+  return params;
+}
+
+function flatten(params: any, data: FlattenableValue, path: string) {
+  for (const key of Object.keys(data)) {
+    if (data[key] instanceof Array) {
+      data[key].forEach((item: FlattenableValue, index: number) => {
+        if (item instanceof Object) {
+          flatten(params, item, `${path}${key}[${index}].`);
+        } else {
+          params[`${path}${key}[${index}]`] = item;
+        }
+      });
+    } else if (data[key]?.constructor === Object) {
+      flatten(params, data[key], `${path}${key}.`);
+    } else {
+      params[`${path}${key}`] = data[key];
+    }
+  }
+}
+
+type ResponseResult<T, U extends number = 0> = {
+  status: U;
+  response: U extends 0 ? unknown : T;
+};
+
+function createQueryUrl(url: string, paramsObject: QueryParams) {
+  const queryString = Object.entries(flattenQueryParams(paramsObject))
+    .map(([key, val]) => {
+			
+			if (key && val !== null && val !== undefined) {
+				return Array.isArray(val) 
+					? val.map((item) => `${encodeURIComponent(key)}=${encodeURIComponent(item)}`).join('&') 
+					: `${encodeURIComponent(key)}=${encodeURIComponent(val)}`;
+			}
+			return null;
+		})
+		.filter(p => !!p)
+    .join("&");
+
+  const maybeQueryString = queryString.length > 0 ? `?${queryString}` : "";
+  return `${url}${maybeQueryString}`;
+}
+
+function parseErrorResponse<T>(error: unknown): T | unknown {
+	try {
+		return JSON.parse(error as string) as T;
+	} catch (e) {
+		return error;
+	}
+}
+
+function apiGet<T extends ResponseResult<unknown, number>>(
+	httpClient: HttpClient,
+	url: string,
+	params?: QueryParams,
+): Observable<T | never> {
+	const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.get<HttpResponse<T['response']>>(queryUrl, { observe: 'response' })
+		.pipe(
+			map(
+				(r) =>
+					({
+						status: r.status,
+						response: r.body as T['response'],
+					} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+function apiGetFile<T extends ResponseResult<unknown, number>>(
+	httpClient: HttpClient,
+	url: string,
+	params?: QueryParams,
+): Observable<T | never> {
+	const mapResult = (response: HttpResponse<Blob>) => {
+		const contentDisposition = response.headers ? response.headers.get("content-disposition") : undefined;
+		let fileNameMatch = contentDisposition ? /filename\*=(?:(\?['"])(.*?)\1|(?:[^\s]+'.*?')?([^;\n]*))/g.exec(contentDisposition) : undefined;
+		let fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[3] || fileNameMatch[2] : undefined;
+		if (fileName) {
+			fileName = decodeURIComponent(fileName);
+		} else {
+			fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
+			fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+		}
+		return { data: response.body, fileName: fileName };
+	}
+
+	const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.get(queryUrl, { observe: 'response', responseType: "blob" })
+		.pipe(
+			map(
+				(r) =>
+				({
+					status: r.status,
+					response: mapResult(r),
+				} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+function apiPost<T extends ResponseResult<unknown, number>, U = unknown>(
+	httpClient: HttpClient,
+	url: string,
+	body: U,
+  params?: QueryParams,
+): Observable<T | never> {
+  const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.post<HttpResponse<T['response']>>(queryUrl, body, {
+			observe: 'response',
+		})
+		.pipe(
+			map(
+				(r) =>
+					({
+						status: r.status,
+						response: r.body as T['response'],
+					} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+function apiPut<T extends ResponseResult<unknown, number>, U = unknown>(
+	httpClient: HttpClient,
+	url: string,
+	body: U,
+  params?: QueryParams,
+): Observable<T | never> {
+  const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.put<HttpResponse<T['response']>>(queryUrl, body, {
+			observe: 'response',
+		})
+		.pipe(
+			map(
+				(r) =>
+					({
+						status: r.status,
+						response: r.body as T['response'],
+					} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+function apiDelete<T extends ResponseResult<unknown, number>>(
+	httpClient: HttpClient,
+	url: string,
+	params?: QueryParams,
+) {
+	const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.delete<HttpResponse<T['response']>>(queryUrl, { observe: 'response' })
+		.pipe(
+			map(
+				(r) =>
+					({
+						status: r.status,
+						response: r.body as T['response'],
+					} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+function apiPatch<T extends ResponseResult<unknown, number>, U = unknown>(
+	httpClient: HttpClient,
+	url: string,
+	body: U,
+  params?: QueryParams,
+): Observable<T | never> {
+  const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.patch<HttpResponse<T['response']>>(queryUrl, body, {
+			observe: 'response',
+		})
+		.pipe(
+			map(
+				(r) =>
+					({
+						status: r.status,
+						response: r.body as T['response'],
+					} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+  // INFRASTRUCTURE END
+
+export interface FileResponse {
+  data: Blob;
+  fileName?: string;
+}
+  
+export type Pet = {
+	discriminator: string;
+};
+
+export type Dog = {
+	discriminator: string;
+	woof: boolean;
+};
+
+export type Cat = {
+	discriminator: string;
+	eat: boolean;
+	meow: boolean;
+};
+
+export type Cow = {
+	moo: boolean;
+	discriminator: string;
+};
+
+
+
+export const API_BASE_URL = new InjectionToken<string>('API_BASE_URL');
+
+@Injectable()
+export class ApiService {
+  private httpClient: HttpClient;
+  private baseUrl: string;
+
+  constructor(
+    @Inject(HttpClient) httpClient: HttpClient,
+    @Optional() @Inject(API_BASE_URL) baseUrl?: string
+  ) {
+      this.httpClient = httpClient;
+      this.baseUrl = baseUrl ?? "";
+  }
+
+  
+	
+    getTest(): Observable<ResponseResult<{status: string;
+	data?: Dog | Cat | Cow | null;}, 200>> {
+      
+      return apiGet<ResponseResult<{status: string;
+	data?: Dog | Cat | Cow | null;}, 200>>(this.httpClient, `${this.baseUrl}/api/test`);
+    }
+    
+
+
+}
+  
+  

--- a/packages/core/src/tests/fixtures/allof_anonymous_schema.json
+++ b/packages/core/src/tests/fixtures/allof_anonymous_schema.json
@@ -1,0 +1,131 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Swagger sample schema for anonymous schmea inside allOf attribute",
+    "description": "Example swagger json for github issue",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "\/api\/test": {
+      "get": {
+        "summary": "Test route",
+        "operationId": "4154a669519b96e4c7ac0c3e208e1dc0",
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application\/json": {
+                "schema": {
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "data": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/Dog"
+                        },
+                        {
+                          "$ref": "#/components/schemas/Cat"
+                        },
+                        {
+                          "$ref": "#/components/schemas/Cow"
+                        }
+                      ],
+                      "nullable": true
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "properties": {
+          "discriminator": {
+            "type": "string"
+          }
+        },
+        "type": "object",
+        "discriminator": {
+          "propertyName": "discriminator"
+        }
+      },
+      "Dog": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "properties": {
+              "woof": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "Cat": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          },
+          {
+            "allOf": [
+              {
+                "allOf": [
+                  {
+                    "allOf": [
+                      {
+                        "properties": {
+                          "eat": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object"
+                      }
+                    ],
+                    "type": "object"
+                  }
+                ],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "meow": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "object"
+              }
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "Cow": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          }
+        ],
+        "properties": {
+          "moo": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/tests/generate.test.ts
+++ b/packages/core/src/tests/generate.test.ts
@@ -2,7 +2,7 @@ import SwaggerParser from "@apidevtools/swagger-parser";
 import { describe, expect, test } from "vitest";
 import { generate } from "../lib/generators";
 
-const cases = ["petstore", "nswag", "anonymous_object"];
+const cases = ["petstore", "nswag", "anonymous_object", "allof_anonymous_schema"];
 
 function fixturePath(name: string) {
   return `./src/tests/fixtures/${name}.json`;


### PR DESCRIPTION
Currently, only properties outside the allOf attribute are supported:
<img width="308" alt="image" src="https://github.com/gaboe/rest2ts/assets/144771488/adbd1017-9d10-40ce-b670-4811edc669fa">
Generated code:
<img width="192" alt="image" src="https://github.com/gaboe/rest2ts/assets/144771488/e5fd0537-c79c-41db-a703-971b2203c8ca">

This PR adds support for anonymous schemas with properties defined inside the allOf attribute:
<img width="307" alt="image" src="https://github.com/gaboe/rest2ts/assets/144771488/58aa1141-ffcb-442b-a31b-2361a91430e1">

Here is an example of the generated code before and after the change:

**Before**
<img width="194" alt="image" src="https://github.com/gaboe/rest2ts/assets/144771488/f38e6b9e-e2b5-4481-b946-4aca16dc2b3e">

**After**
<img width="196" alt="image" src="https://github.com/gaboe/rest2ts/assets/144771488/2dc45a25-09ed-4319-b32d-ee72622ed498">