### PR TITLE
Multipart/form-data updates

### DIFF
--- a/apps/cli/src/lib/generators/Common.ts
+++ b/apps/cli/src/lib/generators/Common.ts
@@ -61,12 +61,14 @@ export const renderProperties =
             const type = renderProperties(swagger)(childProp);
 
             const isNullable: boolean = (childProp as any).nullable;
+            const isNameArray = op.endsWith('[]');
+            const propertyName = isNameArray ? `"${op}"` : op;
 
             const view = {
-              name: isNullable ? `${op}?` : op,
+              name: isNullable ? `${propertyName}?` : propertyName,
               type: isNullable ? `${type} | null` : type,
             };
-            return render("{{ name }}: {{{ type }}};", view);
+            return render("{{{ name }}}: {{{ type }}};", view);
           })
           .join("\n\t");
         return properties.concat(addSchemaAllOf(schema.allOf ?? null, swagger));

--- a/apps/cli/src/lib/renderers/InfrastructureTemplates.ts
+++ b/apps/cli/src/lib/renderers/InfrastructureTemplates.ts
@@ -22,7 +22,11 @@ const commonInfrastructure = `
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/lib/renderers/InfrastructureTemplates.ts
+++ b/apps/cli/src/lib/renderers/InfrastructureTemplates.ts
@@ -16,16 +16,20 @@ const commonInfrastructure = `
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema.ts
@@ -221,16 +221,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema.ts
@@ -227,7 +227,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema_angular.ts
@@ -36,16 +36,20 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema_angular.ts
@@ -42,7 +42,11 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema_cookies.ts
@@ -228,7 +228,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_allof_anonymous_schema_cookies.ts
@@ -222,16 +222,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_anonymous_object.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_anonymous_object.ts
@@ -221,16 +221,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_anonymous_object.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_anonymous_object.ts
@@ -227,7 +227,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_anonymous_object_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_anonymous_object_angular.ts
@@ -36,16 +36,20 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_anonymous_object_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_anonymous_object_angular.ts
@@ -42,7 +42,11 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_anonymous_object_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_anonymous_object_cookies.ts
@@ -228,7 +228,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_anonymous_object_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_anonymous_object_cookies.ts
@@ -222,16 +222,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_auth_login.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_auth_login.ts
@@ -221,16 +221,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_auth_login.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_auth_login.ts
@@ -227,7 +227,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_auth_login_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_auth_login_angular.ts
@@ -36,16 +36,20 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_auth_login_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_auth_login_angular.ts
@@ -42,7 +42,11 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_auth_login_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_auth_login_cookies.ts
@@ -228,7 +228,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_auth_login_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_auth_login_cookies.ts
@@ -222,16 +222,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_bracket_params.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_bracket_params.ts
@@ -221,16 +221,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_bracket_params.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_bracket_params.ts
@@ -227,7 +227,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_bracket_params_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_bracket_params_angular.ts
@@ -36,16 +36,20 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_bracket_params_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_bracket_params_angular.ts
@@ -42,7 +42,11 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_bracket_params_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_bracket_params_cookies.ts
@@ -228,7 +228,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_bracket_params_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_bracket_params_cookies.ts
@@ -222,16 +222,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata.ts
@@ -221,16 +221,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata.ts
@@ -227,7 +227,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_angular.ts
@@ -36,16 +36,20 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_angular.ts
@@ -42,7 +42,11 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_cookies.ts
@@ -228,7 +228,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_cookies.ts
@@ -222,16 +222,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles.ts
@@ -221,16 +221,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles.ts
@@ -1,0 +1,476 @@
+/* eslint-disable */
+// THIS FILE WAS GENERATED
+// ALL CHANGES WILL BE OVERWRITTEN
+
+// INFRASTRUCTURE START
+  export type StandardError = globalThis.Error;
+  export type Error500s = 501 | 502 | 503 | 504 | 505 | 506 | 507 | 508 | 510 | 511;
+  export type ErrorStatuses = 0 | Error500s;
+  export type ErrorResponse = FetchResponse<unknown, ErrorStatuses>;
+
+  export type FetchResponseOfError = {
+    data: null;
+    error: StandardError;
+    status: ErrorStatuses;
+    args: any;
+  };
+
+  export type FetchResponseOfSuccess<TData, TStatus extends number = 0> = 
+  {
+    data: TData;
+    error: null;
+    status: TStatus;
+    args: any;
+    responseHeaders: Headers;
+  };
+
+  export type FetchResponse<TData, TStatus extends number = 0> = 
+    TStatus extends ErrorStatuses ? FetchResponseOfError: FetchResponseOfSuccess<TData, TStatus>;
+
+  export type TerminateRequest = null;
+  export type TerminateResponse = null;
+
+  export type Configuration = {
+    apiUrl: string | (() => string);
+    jwtKey: string | undefined | (() => string | null | undefined);
+    requestMiddlewares?: Array<{
+      name: string;
+      fn: (request: FetchArgs) => FetchArgs | TerminateRequest;
+    }>;
+    responseMiddlewares?: Array<{
+      name: string;
+      fn: (
+        response: FetchResponse<unknown, any>
+      ) => FetchResponse<unknown, any> | TerminateResponse;
+    }>;
+  };
+
+  let CONFIG: Configuration = {
+    apiUrl: () => "",
+    jwtKey: undefined,
+    requestMiddlewares: [],
+    responseMiddlewares: [],
+  };
+
+  export function setupClient(configuration: Configuration) {
+    CONFIG = {
+      ...CONFIG,
+      ...configuration,
+      requestMiddlewares: [
+        ...(CONFIG.requestMiddlewares || []),
+        ...(configuration.requestMiddlewares || []),
+      ],
+      responseMiddlewares: [
+        ...(CONFIG.responseMiddlewares || []),
+        ...(configuration.responseMiddlewares || []),
+      ],
+    };
+  }
+
+  export function getApiUrl() {
+    if (typeof CONFIG.apiUrl === "function") {
+      return CONFIG.apiUrl();
+    }
+    return CONFIG.apiUrl;
+  }
+
+  export type Termination = {
+    termination: {
+      name: string;
+    };
+  };
+
+  export function processRequestWithMiddlewares(
+    request: FetchArgs
+  ): FetchArgs | Termination {
+    for (const middleware of CONFIG.requestMiddlewares || []) {
+      try {
+        const middlewareResponse = middleware.fn(request);
+        if (middlewareResponse === null) {
+          return { termination: { name: middleware.name } };
+        }
+        request = middlewareResponse;
+      } catch (e) {
+        console.error("Request middleware error", e);
+      }
+    }
+    return request;
+  }
+
+  export function processResponseWithMiddlewares<T extends FetchResponse<unknown, any>>(
+    response: T
+  ): T | Termination {
+    for (const middleware of CONFIG.responseMiddlewares || []) {
+      try {
+        const middlewareResponse = middleware.fn(response);
+        if (middlewareResponse === null) {
+          return {
+            status: 0,
+            args: response.args,
+            data: null,
+            error: new Error(
+              `Response terminated by middleware: ${middleware.name}`
+            ),
+          } as FetchResponseOfError as unknown as T;
+        }
+        response = middlewareResponse as T;
+      } catch (e) {
+        console.error("Response middleware error", e);
+      }
+    }
+    return response;
+  }
+
+  export type FetchOptions = {
+    method: string;
+    headers: Headers;
+    body?: any;
+    redirect: RequestRedirect;
+  };
+
+  export type FetchArgs = {
+    url: string;
+    options: FetchOptions;
+  }
+
+  export async function fetchJson<T extends FetchResponse<unknown, number>>(
+    args: FetchArgs
+  ): Promise<T> {
+    const errorResponse = (error: StandardError, status: number, args: any) => {
+      const errorResponse = {
+        status: status as ErrorStatuses,
+        args,
+        data: null,
+        error,
+      } satisfies FetchResponse<T>;
+
+      return processResponseWithMiddlewares(errorResponse) as unknown as T;
+    };
+
+    const errorStatus = (args: any) => {
+      const errorResponse = {
+        status: 0,
+        args,
+        data: null,
+        error: new Error("Network error"),
+      } as FetchResponse<T, Error500s>;
+
+      return processResponseWithMiddlewares(errorResponse) as unknown as T;
+    };
+
+    try {
+      const fetchRequest = processRequestWithMiddlewares(args);
+
+      if ("termination" in fetchRequest) {
+        const terminationResponse = {
+          status: 0,
+          args,
+          data: null,
+          error: new Error(
+            `Request terminated by middleware: ${fetchRequest.termination.name}`
+          ),
+        } as FetchResponse<T, Error500s>;
+
+        return processResponseWithMiddlewares(
+          terminationResponse
+        ) as unknown as T;
+      }
+
+      const fetchResponse: Response = await fetch(fetchRequest.url, fetchRequest.options);
+      const status = fetchResponse.status;
+      try {
+        const json = await fetchResponse.json();
+        const response = {
+          data: json,
+          status: fetchResponse.status,
+          args,
+          error: null,
+          responseHeaders: fetchResponse.headers,
+        };
+        return processResponseWithMiddlewares(response) as unknown as T;
+      } catch (error) {
+        return errorResponse(error as StandardError, status, args);
+      }
+    } catch {
+      return errorStatus(args);
+    }
+  }
+
+  export function getJwtKey(): string | null | undefined {
+    if (typeof CONFIG.jwtKey === "function") {
+      return CONFIG.jwtKey();
+    }
+
+    if (typeof CONFIG.jwtKey === "string") {
+      return localStorage.getItem(CONFIG.jwtKey);
+    }
+
+    return undefined;
+  } 
+  
+  
+ function getApiRequestData<Type extends any>(
+    requestContract: Type | undefined,
+    isFormData: boolean = false
+  ): FormData | Type | {} {
+  
+    if (!isFormData) {
+      return requestContract !== undefined ? requestContract : {};
+    }
+  
+    //multipart/form-data
+    const formData = new FormData();
+  
+    if (requestContract) {
+      Object.keys(requestContract).forEach(key => {
+        const value = requestContract[key as keyof Type];
+        if (value instanceof File) {
+          formData.append(key, value);
+        } else if (typeof value === 'object' && value !== null) {
+          formData.append(key, JSON.stringify(value));
+        } else {
+          formData.append(key, value as any);
+        }
+      });
+    }
+  
+    return formData;
+  }
+
+  
+  function updateHeadersAndGetBody<TResponse extends FetchResponse<unknown, number>, TRequest>(
+    request: TRequest,
+    headers: Headers
+  ) {
+    if (request instanceof FormData) {
+      headers.delete("Content-Type");
+      return request;
+    } else {
+      updateHeaders(headers);
+      return JSON.stringify(request);
+    }
+  }
+  
+  function updateHeaders(headers: Headers) {
+    if (!headers.has("Content-Type")) {
+      headers.append("Content-Type", "application/json");
+    }
+    const token = getJwtKey();
+    if (!headers.has("Authorization") && !!token) {
+      headers.append("Authorization", token);
+    }
+  }
+
+export function getQueryParamsString(paramsObject: ParamsObject = {}) {
+	const queryString = Object.entries(paramsObject)
+    .map(([key, value]) => {
+      if (Array.isArray(value)) {
+        return value
+          .map(val => `${encodeURIComponent(key)}=${encodeURIComponent(
+            val,
+          )}`)
+          .join('&');
+      }
+      // Handling non-array parameters
+      return value !== undefined && value !== null 
+        ? `${encodeURIComponent(key)}=${encodeURIComponent(value)}` 
+        : '';
+    })
+    .filter(part => part !== '')
+    .join("&");
+
+	return queryString.length > 0 ? `?${queryString}` : '';
+}
+
+export function apiPost<TResponse extends FetchResponse<unknown, number>, TRequest>(
+  url: string,
+  request: TRequest,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  
+  const raw = updateHeadersAndGetBody(request, headers); 
+
+  const requestOptions: FetchOptions = {
+    method: "POST",
+    headers,
+    body: raw,
+    redirect: "follow",
+  };
+
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+export type ParamsObject = {
+  [key: string]: any;
+};
+
+export function apiGet<TResponse extends FetchResponse<unknown, number>>(
+  url: string,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+  
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  const requestOptions: FetchOptions = {
+    method: "GET",
+    headers,
+    redirect: "follow",
+  };
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+export function apiPut<TResponse extends FetchResponse<unknown, number>, TRequest>(
+  url: string,
+  request: TRequest,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+
+  const raw = JSON.stringify(request);
+
+  const requestOptions: FetchOptions = {
+    method: "PUT",
+    headers,
+    body: raw,
+    redirect: "follow",
+  };
+
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+export function apiDelete<TResponse extends FetchResponse<unknown, number>>(
+  url: string,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+
+  const queryString = Object.entries(paramsObject)
+    .filter(([_, val]) => val !== undefined && val !== null)
+    .map(([key, val]) => `${key}=${val}`)
+    .join("&");
+  
+  const maybeQueryString = queryString.length > 0 ? `?${queryString}` : "";
+
+  const requestOptions: FetchOptions = {
+    method: "DELETE",
+    headers,
+    redirect: "follow",
+  };
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+export function apiPatch<TResponse extends FetchResponse<unknown, number>, TRequest>(
+  url: string,
+  request: TRequest,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+
+  const raw = JSON.stringify(request);
+
+  const requestOptions: FetchOptions = {
+    method: "PATCH",
+    headers,
+    body: raw,
+    redirect: "follow",
+  };
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+// INFRASTRUCTURE END
+
+export enum ElectronicTradeFormalityEnum {
+	BlueAgreement = "BlueAgreement",
+	AML = "AML",
+	Termination = "Termination",
+	TransferUnderSAB = "TransferUnderSAB",
+	Change = "Change",
+	LoanProtocolHandover = "LoanProtocolHandover",
+	TradeProducerProtocol = "TradeProducerProtocol",
+	Modelation = "Modelation",
+	Other = "Other",
+	ZZJ = "ZZJ",
+	TradeIdentificationForm = "TradeIdentificationForm",
+	NewInstruction = "NewInstruction",
+	LoanRequest = "LoanRequest",
+	ESIP = "ESIP",
+	Contract = "Contract"
+};
+
+export type ErrorDetailDTO = {
+	code: string;
+	message: string;
+};
+
+export type ExceptionDTO = {
+	errors?: { [key: string | number]: ErrorDetailDTO[] } | null;
+	type?: string | null;
+	title?: string | null;
+	status?: number | null;
+	detail?: string | null;
+	instance?: string | null;
+	stackTrace?: { [key: string | number]: ExceptionStackTraceItemDTO[] } | null;
+};
+
+export type ExceptionStackTraceItemDTO = {
+	file?: string | null;
+	line?: number | null;
+	function?: string | null;
+	class?: string | null;
+	type?: string | null;
+};
+
+export type ElectronicTradeFormalityDataRequestDTO = {
+	formalityType: ElectronicTradeFormalityEnum;
+	sendByPostOffice?: boolean | null;
+	targetRelationId?: number | null;
+};
+
+export type ElectronicTradeFormalityRequestDTO = {
+	data: ElectronicTradeFormalityDataRequestDTO;
+	"files[]": File[];
+};
+
+export type PostElectronicTradeTradesElectronicTradeIdFormalityFetchResponse = 
+| FetchResponse<void, 204> 
+| ErrorResponse;
+
+export const postElectronicTradeTradesElectronicTradeIdFormalityPath = (electronicTradeId: number, fields?: string) => `/api/electronic-trade/trades/${electronicTradeId}/formality`;
+
+export const postElectronicTradeTradesElectronicTradeIdFormality = (requestContract: ElectronicTradeFormalityRequestDTO, electronicTradeId: number, fields?: string, headers = new Headers()): 
+	Promise<PostElectronicTradeTradesElectronicTradeIdFormalityFetchResponse> => {
+	const queryParams = {
+		"fields": fields
+	}
+	
+    const requestData = getApiRequestData<ElectronicTradeFormalityRequestDTO>(requestContract, true);
+    return apiPost(`${getApiUrl()}${postElectronicTradeTradesElectronicTradeIdFormalityPath(electronicTradeId)}`, requestData, headers, queryParams) as Promise<PostElectronicTradeTradesElectronicTradeIdFormalityFetchResponse>;
+}

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles.ts
@@ -227,7 +227,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_angular.ts
@@ -36,16 +36,20 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_angular.ts
@@ -42,7 +42,11 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_angular.ts
@@ -1,0 +1,376 @@
+/* eslint-disable */
+// THIS FILE WAS GENERATED
+// ALL CHANGES WILL BE OVERWRITTEN
+
+// INFRASTRUCTURE START
+
+import { HttpClient, HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { Inject, Injectable, InjectionToken, Optional } from '@angular/core';
+import { Observable, of, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+type FlattenableValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Date
+  | FlattenableValue[]
+  | {
+      [prop: string]: FlattenableValue;
+    };
+
+type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
+
+
+ function getApiRequestData<Type extends any>(
+    requestContract: Type | undefined,
+    isFormData: boolean = false
+  ): FormData | Type | {} {
+  
+    if (!isFormData) {
+      return requestContract !== undefined ? requestContract : {};
+    }
+  
+    //multipart/form-data
+    const formData = new FormData();
+  
+    if (requestContract) {
+      Object.keys(requestContract).forEach(key => {
+        const value = requestContract[key as keyof Type];
+        if (value instanceof File) {
+          formData.append(key, value);
+        } else if (typeof value === 'object' && value !== null) {
+          formData.append(key, JSON.stringify(value));
+        } else {
+          formData.append(key, value as any);
+        }
+      });
+    }
+  
+    return formData;
+  }
+
+
+function flattenQueryParams(data: QueryParams) {
+  const params: Record<string, any> = {};
+  flatten(params, data, '');
+  return params;
+}
+
+function flatten(params: any, data: FlattenableValue, path: string) {
+  for (const key of Object.keys(data)) {
+    if (data[key] instanceof Array) {
+      data[key].forEach((item: FlattenableValue, index: number) => {
+        if (item instanceof Object) {
+          flatten(params, item, `${path}${key}[${index}].`);
+        } else {
+          params[`${path}${key}[${index}]`] = item;
+        }
+      });
+    } else if (data[key]?.constructor === Object) {
+      flatten(params, data[key], `${path}${key}.`);
+    } else {
+      params[`${path}${key}`] = data[key];
+    }
+  }
+}
+
+type ResponseResult<T, U extends number = 0> = {
+  status: U;
+  response: U extends 0 ? unknown : T;
+};
+
+function createQueryUrl(url: string, paramsObject: QueryParams) {
+  const queryString = Object.entries(flattenQueryParams(paramsObject))
+    .map(([key, val]) => {
+			
+			if (key && val !== null && val !== undefined) {
+				return Array.isArray(val) 
+					? val.map((item) => `${encodeURIComponent(key)}=${encodeURIComponent(item)}`).join('&') 
+					: `${encodeURIComponent(key)}=${encodeURIComponent(val)}`;
+			}
+			return null;
+		})
+		.filter(p => !!p)
+    .join("&");
+
+  const maybeQueryString = queryString.length > 0 ? `?${queryString}` : "";
+  return `${url}${maybeQueryString}`;
+}
+
+function parseErrorResponse<T>(error: unknown): T | unknown {
+	try {
+		return JSON.parse(error as string) as T;
+	} catch (e) {
+		return error;
+	}
+}
+
+function apiGet<T extends ResponseResult<unknown, number>>(
+	httpClient: HttpClient,
+	url: string,
+	params?: QueryParams,
+): Observable<T | never> {
+	const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.get<HttpResponse<T['response']>>(queryUrl, { observe: 'response' })
+		.pipe(
+			map(
+				(r) =>
+					({
+						status: r.status,
+						response: r.body as T['response'],
+					} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+function apiGetFile<T extends ResponseResult<unknown, number>>(
+	httpClient: HttpClient,
+	url: string,
+	params?: QueryParams,
+): Observable<T | never> {
+	const mapResult = (response: HttpResponse<Blob>) => {
+		const contentDisposition = response.headers ? response.headers.get("content-disposition") : undefined;
+		let fileNameMatch = contentDisposition ? /filename\*=(?:(\?['"])(.*?)\1|(?:[^\s]+'.*?')?([^;\n]*))/g.exec(contentDisposition) : undefined;
+		let fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[3] || fileNameMatch[2] : undefined;
+		if (fileName) {
+			fileName = decodeURIComponent(fileName);
+		} else {
+			fileNameMatch = contentDisposition ? /filename="?([^"]*?)"?(;|$)/g.exec(contentDisposition) : undefined;
+			fileName = fileNameMatch && fileNameMatch.length > 1 ? fileNameMatch[1] : undefined;
+		}
+		return { data: response.body, fileName: fileName };
+	}
+
+	const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.get(queryUrl, { observe: 'response', responseType: "blob" })
+		.pipe(
+			map(
+				(r) =>
+				({
+					status: r.status,
+					response: mapResult(r),
+				} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+function apiPost<T extends ResponseResult<unknown, number>, U = unknown>(
+	httpClient: HttpClient,
+	url: string,
+	body: U,
+  params?: QueryParams,
+): Observable<T | never> {
+  const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.post<HttpResponse<T['response']>>(queryUrl, body, {
+			observe: 'response',
+		})
+		.pipe(
+			map(
+				(r) =>
+					({
+						status: r.status,
+						response: r.body as T['response'],
+					} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+function apiPut<T extends ResponseResult<unknown, number>, U = unknown>(
+	httpClient: HttpClient,
+	url: string,
+	body: U,
+  params?: QueryParams,
+): Observable<T | never> {
+  const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.put<HttpResponse<T['response']>>(queryUrl, body, {
+			observe: 'response',
+		})
+		.pipe(
+			map(
+				(r) =>
+					({
+						status: r.status,
+						response: r.body as T['response'],
+					} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+function apiDelete<T extends ResponseResult<unknown, number>>(
+	httpClient: HttpClient,
+	url: string,
+	params?: QueryParams,
+) {
+	const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.delete<HttpResponse<T['response']>>(queryUrl, { observe: 'response' })
+		.pipe(
+			map(
+				(r) =>
+					({
+						status: r.status,
+						response: r.body as T['response'],
+					} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+function apiPatch<T extends ResponseResult<unknown, number>, U = unknown>(
+	httpClient: HttpClient,
+	url: string,
+	body: U,
+  params?: QueryParams,
+): Observable<T | never> {
+  const queryUrl = !!params ? createQueryUrl(url, params) : url;
+	return httpClient
+		.patch<HttpResponse<T['response']>>(queryUrl, body, {
+			observe: 'response',
+		})
+		.pipe(
+			map(
+				(r) =>
+					({
+						status: r.status,
+						response: r.body as T['response'],
+					} as T),
+			),
+			catchError((err) => {
+				if (err instanceof HttpErrorResponse) {
+					return of({ status: err.status, response: parseErrorResponse<T>(err.error) }) as Observable<T>;
+				}
+				return throwError(() => err);
+			}),
+		);
+}
+
+  // INFRASTRUCTURE END
+
+export interface FileResponse {
+  data: Blob;
+  fileName?: string;
+}
+  
+export enum ElectronicTradeFormalityEnum {
+	BlueAgreement = "BlueAgreement",
+	AML = "AML",
+	Termination = "Termination",
+	TransferUnderSAB = "TransferUnderSAB",
+	Change = "Change",
+	LoanProtocolHandover = "LoanProtocolHandover",
+	TradeProducerProtocol = "TradeProducerProtocol",
+	Modelation = "Modelation",
+	Other = "Other",
+	ZZJ = "ZZJ",
+	TradeIdentificationForm = "TradeIdentificationForm",
+	NewInstruction = "NewInstruction",
+	LoanRequest = "LoanRequest",
+	ESIP = "ESIP",
+	Contract = "Contract"
+};
+
+export type ErrorDetailDTO = {
+	code: string;
+	message: string;
+};
+
+export type ExceptionDTO = {
+	errors?: { [key: string | number]: ErrorDetailDTO[] } | null;
+	type?: string | null;
+	title?: string | null;
+	status?: number | null;
+	detail?: string | null;
+	instance?: string | null;
+	stackTrace?: { [key: string | number]: ExceptionStackTraceItemDTO[] } | null;
+};
+
+export type ExceptionStackTraceItemDTO = {
+	file?: string | null;
+	line?: number | null;
+	function?: string | null;
+	class?: string | null;
+	type?: string | null;
+};
+
+export type ElectronicTradeFormalityDataRequestDTO = {
+	formalityType: ElectronicTradeFormalityEnum;
+	sendByPostOffice?: boolean | null;
+	targetRelationId?: number | null;
+};
+
+export type ElectronicTradeFormalityRequestDTO = {
+	data: ElectronicTradeFormalityDataRequestDTO;
+	"files[]": File[];
+};
+
+
+
+export const API_BASE_URL = new InjectionToken<string>('API_BASE_URL');
+
+@Injectable()
+export class ApiService {
+  private httpClient: HttpClient;
+  private baseUrl: string;
+
+  constructor(
+    @Inject(HttpClient) httpClient: HttpClient,
+    @Optional() @Inject(API_BASE_URL) baseUrl?: string
+  ) {
+      this.httpClient = httpClient;
+      this.baseUrl = baseUrl ?? "";
+  }
+
+  
+	
+    postElectronicTradeTradesElectronicTradeIdFormality(requestContract: ElectronicTradeFormalityRequestDTO, electronicTradeId: number, fields?: string): Observable<ResponseResult<void, 204>> {
+	const queryParams = {
+		"fields": fields
+	}
+	
+    const requestData = getApiRequestData<ElectronicTradeFormalityRequestDTO>(requestContract, true);
+    
+      return apiPost<ResponseResult<void, 204>>(this.httpClient, `${this.baseUrl}/api/electronic-trade/trades/${electronicTradeId}/formality`, requestData, queryParams);
+    }
+  
+
+
+}
+  
+  
+

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_cookies.ts
@@ -228,7 +228,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_cookies.ts
@@ -222,16 +222,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_multipart_formdata_multiplefiles_cookies.ts
@@ -1,0 +1,482 @@
+/* eslint-disable */
+// THIS FILE WAS GENERATED
+// ALL CHANGES WILL BE OVERWRITTEN
+
+// INFRASTRUCTURE START
+  export type StandardError = globalThis.Error;
+  export type Error500s = 501 | 502 | 503 | 504 | 505 | 506 | 507 | 508 | 510 | 511;
+  export type ErrorStatuses = 0 | Error500s;
+  export type ErrorResponse = FetchResponse<unknown, ErrorStatuses>;
+
+  export type FetchResponseOfError = {
+    data: null;
+    error: StandardError;
+    status: ErrorStatuses;
+    args: any;
+  };
+
+  export type FetchResponseOfSuccess<TData, TStatus extends number = 0> = 
+  {
+    data: TData;
+    error: null;
+    status: TStatus;
+    args: any;
+    responseHeaders: Headers;
+  };
+
+  export type FetchResponse<TData, TStatus extends number = 0> = 
+    TStatus extends ErrorStatuses ? FetchResponseOfError: FetchResponseOfSuccess<TData, TStatus>;
+
+  export type TerminateRequest = null;
+  export type TerminateResponse = null;
+
+  export type Configuration = {
+    apiUrl: string | (() => string);
+    jwtKey: string | undefined | (() => string | null | undefined);
+    requestMiddlewares?: Array<{
+      name: string;
+      fn: (request: FetchArgs) => FetchArgs | TerminateRequest;
+    }>;
+    responseMiddlewares?: Array<{
+      name: string;
+      fn: (
+        response: FetchResponse<unknown, any>
+      ) => FetchResponse<unknown, any> | TerminateResponse;
+    }>;
+  };
+
+  let CONFIG: Configuration = {
+    apiUrl: () => "",
+    jwtKey: undefined,
+    requestMiddlewares: [],
+    responseMiddlewares: [],
+  };
+
+  export function setupClient(configuration: Configuration) {
+    CONFIG = {
+      ...CONFIG,
+      ...configuration,
+      requestMiddlewares: [
+        ...(CONFIG.requestMiddlewares || []),
+        ...(configuration.requestMiddlewares || []),
+      ],
+      responseMiddlewares: [
+        ...(CONFIG.responseMiddlewares || []),
+        ...(configuration.responseMiddlewares || []),
+      ],
+    };
+  }
+
+  export function getApiUrl() {
+    if (typeof CONFIG.apiUrl === "function") {
+      return CONFIG.apiUrl();
+    }
+    return CONFIG.apiUrl;
+  }
+
+  export type Termination = {
+    termination: {
+      name: string;
+    };
+  };
+
+  export function processRequestWithMiddlewares(
+    request: FetchArgs
+  ): FetchArgs | Termination {
+    for (const middleware of CONFIG.requestMiddlewares || []) {
+      try {
+        const middlewareResponse = middleware.fn(request);
+        if (middlewareResponse === null) {
+          return { termination: { name: middleware.name } };
+        }
+        request = middlewareResponse;
+      } catch (e) {
+        console.error("Request middleware error", e);
+      }
+    }
+    return request;
+  }
+
+  export function processResponseWithMiddlewares<T extends FetchResponse<unknown, any>>(
+    response: T
+  ): T | Termination {
+    for (const middleware of CONFIG.responseMiddlewares || []) {
+      try {
+        const middlewareResponse = middleware.fn(response);
+        if (middlewareResponse === null) {
+          return {
+            status: 0,
+            args: response.args,
+            data: null,
+            error: new Error(
+              `Response terminated by middleware: ${middleware.name}`
+            ),
+          } as FetchResponseOfError as unknown as T;
+        }
+        response = middlewareResponse as T;
+      } catch (e) {
+        console.error("Response middleware error", e);
+      }
+    }
+    return response;
+  }
+
+  export type FetchOptions = {
+    method: string;
+    headers: Headers;
+    body?: any;
+    redirect: RequestRedirect;
+		credentials?: RequestCredentials;
+  };
+
+  export type FetchArgs = {
+    url: string;
+    options: FetchOptions;
+  }
+
+  export async function fetchJson<T extends FetchResponse<unknown, number>>(
+    args: FetchArgs
+  ): Promise<T> {
+    const errorResponse = (error: StandardError, status: number, args: any) => {
+      const errorResponse = {
+        status: status as ErrorStatuses,
+        args,
+        data: null,
+        error,
+      } satisfies FetchResponse<T>;
+
+      return processResponseWithMiddlewares(errorResponse) as unknown as T;
+    };
+
+    const errorStatus = (args: any) => {
+      const errorResponse = {
+        status: 0,
+        args,
+        data: null,
+        error: new Error("Network error"),
+      } as FetchResponse<T, Error500s>;
+
+      return processResponseWithMiddlewares(errorResponse) as unknown as T;
+    };
+
+    try {
+      const fetchRequest = processRequestWithMiddlewares(args);
+
+      if ("termination" in fetchRequest) {
+        const terminationResponse = {
+          status: 0,
+          args,
+          data: null,
+          error: new Error(
+            `Request terminated by middleware: ${fetchRequest.termination.name}`
+          ),
+        } as FetchResponse<T, Error500s>;
+
+        return processResponseWithMiddlewares(
+          terminationResponse
+        ) as unknown as T;
+      }
+
+      const fetchResponse: Response = await fetch(fetchRequest.url, fetchRequest.options);
+      const status = fetchResponse.status;
+      try {
+        const json = await fetchResponse.json();
+        const response = {
+          data: json,
+          status: fetchResponse.status,
+          args,
+          error: null,
+          responseHeaders: fetchResponse.headers,
+        };
+        return processResponseWithMiddlewares(response) as unknown as T;
+      } catch (error) {
+        return errorResponse(error as StandardError, status, args);
+      }
+    } catch {
+      return errorStatus(args);
+    }
+  }
+
+  export function getJwtKey(): string | null | undefined {
+    if (typeof CONFIG.jwtKey === "function") {
+      return CONFIG.jwtKey();
+    }
+
+    if (typeof CONFIG.jwtKey === "string") {
+      return localStorage.getItem(CONFIG.jwtKey);
+    }
+
+    return undefined;
+  } 
+  
+  
+ function getApiRequestData<Type extends any>(
+    requestContract: Type | undefined,
+    isFormData: boolean = false
+  ): FormData | Type | {} {
+  
+    if (!isFormData) {
+      return requestContract !== undefined ? requestContract : {};
+    }
+  
+    //multipart/form-data
+    const formData = new FormData();
+  
+    if (requestContract) {
+      Object.keys(requestContract).forEach(key => {
+        const value = requestContract[key as keyof Type];
+        if (value instanceof File) {
+          formData.append(key, value);
+        } else if (typeof value === 'object' && value !== null) {
+          formData.append(key, JSON.stringify(value));
+        } else {
+          formData.append(key, value as any);
+        }
+      });
+    }
+  
+    return formData;
+  }
+
+  
+  function updateHeadersAndGetBody<TResponse extends FetchResponse<unknown, number>, TRequest>(
+    request: TRequest,
+    headers: Headers
+  ) {
+    if (request instanceof FormData) {
+      headers.delete("Content-Type");
+      return request;
+    } else {
+      updateHeaders(headers);
+      return JSON.stringify(request);
+    }
+  }
+  
+  function updateHeaders(headers: Headers) {
+    if (!headers.has("Content-Type")) {
+      headers.append("Content-Type", "application/json");
+    }
+    const token = getJwtKey();
+    if (!headers.has("Authorization") && !!token) {
+      headers.append("Authorization", token);
+    }
+  }
+
+export function getQueryParamsString(paramsObject: ParamsObject = {}) {
+	const queryString = Object.entries(paramsObject)
+    .map(([key, value]) => {
+      if (Array.isArray(value)) {
+        return value
+          .map(val => `${encodeURIComponent(key)}=${encodeURIComponent(
+            val,
+          )}`)
+          .join('&');
+      }
+      // Handling non-array parameters
+      return value !== undefined && value !== null 
+        ? `${encodeURIComponent(key)}=${encodeURIComponent(value)}` 
+        : '';
+    })
+    .filter(part => part !== '')
+    .join("&");
+
+	return queryString.length > 0 ? `?${queryString}` : '';
+}
+
+export function apiPost<TResponse extends FetchResponse<unknown, number>, TRequest>(
+  url: string,
+  request: TRequest,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  
+  const raw = updateHeadersAndGetBody(request, headers); 
+
+  const requestOptions: FetchOptions = {
+    method: "POST",
+    headers,
+    body: raw,
+    redirect: "follow",
+		credentials: "include",
+  };
+
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+export type ParamsObject = {
+  [key: string]: any;
+};
+
+export function apiGet<TResponse extends FetchResponse<unknown, number>>(
+  url: string,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+  
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  const requestOptions: FetchOptions = {
+    method: "GET",
+    headers,
+    redirect: "follow",
+		credentials: "include",
+  };
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+export function apiPut<TResponse extends FetchResponse<unknown, number>, TRequest>(
+  url: string,
+  request: TRequest,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+
+  const raw = JSON.stringify(request);
+
+  const requestOptions: FetchOptions = {
+    method: "PUT",
+    headers,
+    body: raw,
+    redirect: "follow",
+		credentials: "include",
+  };
+
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+export function apiDelete<TResponse extends FetchResponse<unknown, number>>(
+  url: string,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+
+  const queryString = Object.entries(paramsObject)
+    .filter(([_, val]) => val !== undefined && val !== null)
+    .map(([key, val]) => `${key}=${val}`)
+    .join("&");
+  
+  const maybeQueryString = queryString.length > 0 ? `?${queryString}` : "";
+
+  const requestOptions: FetchOptions = {
+    method: "DELETE",
+    headers,
+    redirect: "follow",
+		credentials: "include",
+  };
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+
+export function apiPatch<TResponse extends FetchResponse<unknown, number>, TRequest>(
+  url: string,
+  request: TRequest,
+  headers: Headers,
+  paramsObject: ParamsObject = {}
+) {
+  updateHeaders(headers);
+
+  const raw = JSON.stringify(request);
+
+  const requestOptions: FetchOptions = {
+    method: "PATCH",
+    headers,
+    body: raw,
+    redirect: "follow",
+		credentials: "include",
+  };
+  const maybeQueryString = getQueryParamsString(paramsObject);
+
+  return fetchJson<TResponse>({
+    url: `${url}${maybeQueryString}`,
+    options: requestOptions,
+  });
+}
+// INFRASTRUCTURE END
+
+export enum ElectronicTradeFormalityEnum {
+	BlueAgreement = "BlueAgreement",
+	AML = "AML",
+	Termination = "Termination",
+	TransferUnderSAB = "TransferUnderSAB",
+	Change = "Change",
+	LoanProtocolHandover = "LoanProtocolHandover",
+	TradeProducerProtocol = "TradeProducerProtocol",
+	Modelation = "Modelation",
+	Other = "Other",
+	ZZJ = "ZZJ",
+	TradeIdentificationForm = "TradeIdentificationForm",
+	NewInstruction = "NewInstruction",
+	LoanRequest = "LoanRequest",
+	ESIP = "ESIP",
+	Contract = "Contract"
+};
+
+export type ErrorDetailDTO = {
+	code: string;
+	message: string;
+};
+
+export type ExceptionDTO = {
+	errors?: { [key: string | number]: ErrorDetailDTO[] } | null;
+	type?: string | null;
+	title?: string | null;
+	status?: number | null;
+	detail?: string | null;
+	instance?: string | null;
+	stackTrace?: { [key: string | number]: ExceptionStackTraceItemDTO[] } | null;
+};
+
+export type ExceptionStackTraceItemDTO = {
+	file?: string | null;
+	line?: number | null;
+	function?: string | null;
+	class?: string | null;
+	type?: string | null;
+};
+
+export type ElectronicTradeFormalityDataRequestDTO = {
+	formalityType: ElectronicTradeFormalityEnum;
+	sendByPostOffice?: boolean | null;
+	targetRelationId?: number | null;
+};
+
+export type ElectronicTradeFormalityRequestDTO = {
+	data: ElectronicTradeFormalityDataRequestDTO;
+	"files[]": File[];
+};
+
+export type PostElectronicTradeTradesElectronicTradeIdFormalityFetchResponse = 
+| FetchResponse<void, 204> 
+| ErrorResponse;
+
+export const postElectronicTradeTradesElectronicTradeIdFormalityPath = (electronicTradeId: number, fields?: string) => `/api/electronic-trade/trades/${electronicTradeId}/formality`;
+
+export const postElectronicTradeTradesElectronicTradeIdFormality = (requestContract: ElectronicTradeFormalityRequestDTO, electronicTradeId: number, fields?: string, headers = new Headers()): 
+	Promise<PostElectronicTradeTradesElectronicTradeIdFormalityFetchResponse> => {
+	const queryParams = {
+		"fields": fields
+	}
+	
+    const requestData = getApiRequestData<ElectronicTradeFormalityRequestDTO>(requestContract, true);
+    return apiPost(`${getApiUrl()}${postElectronicTradeTradesElectronicTradeIdFormalityPath(electronicTradeId)}`, requestData, headers, queryParams) as Promise<PostElectronicTradeTradesElectronicTradeIdFormalityFetchResponse>;
+}

--- a/apps/cli/src/tests/__snapshots__/generate_nswag.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_nswag.ts
@@ -221,16 +221,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_nswag.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_nswag.ts
@@ -227,7 +227,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_nswag_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_nswag_angular.ts
@@ -36,16 +36,20 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_nswag_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_nswag_angular.ts
@@ -42,7 +42,11 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_nswag_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_nswag_cookies.ts
@@ -228,7 +228,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_nswag_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_nswag_cookies.ts
@@ -222,16 +222,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_one_of.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_one_of.ts
@@ -221,16 +221,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_one_of.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_one_of.ts
@@ -227,7 +227,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_one_of_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_one_of_angular.ts
@@ -36,16 +36,20 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_one_of_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_one_of_angular.ts
@@ -42,7 +42,11 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_one_of_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_one_of_cookies.ts
@@ -228,7 +228,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_one_of_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_one_of_cookies.ts
@@ -222,16 +222,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_petstore.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_petstore.ts
@@ -221,16 +221,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_petstore.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_petstore.ts
@@ -227,7 +227,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_petstore_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_petstore_angular.ts
@@ -36,16 +36,20 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_petstore_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_petstore_angular.ts
@@ -42,7 +42,11 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_petstore_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_petstore_cookies.ts
@@ -228,7 +228,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_petstore_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_petstore_cookies.ts
@@ -222,16 +222,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_post_put_bodies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_post_put_bodies.ts
@@ -221,16 +221,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_post_put_bodies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_post_put_bodies.ts
@@ -227,7 +227,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_post_put_bodies_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_post_put_bodies_angular.ts
@@ -36,16 +36,20 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_post_put_bodies_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_post_put_bodies_angular.ts
@@ -42,7 +42,11 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_post_put_bodies_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_post_put_bodies_cookies.ts
@@ -228,7 +228,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_post_put_bodies_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_post_put_bodies_cookies.ts
@@ -222,16 +222,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_swagger_2_0.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_swagger_2_0.ts
@@ -221,16 +221,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_swagger_2_0.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_swagger_2_0.ts
@@ -227,7 +227,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_swagger_2_0_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_swagger_2_0_angular.ts
@@ -36,16 +36,20 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/__snapshots__/generate_swagger_2_0_angular.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_swagger_2_0_angular.ts
@@ -42,7 +42,11 @@ type QueryParams = { [key: string]: FlattenableValue } | null | undefined;
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_swagger_2_0_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_swagger_2_0_cookies.ts
@@ -228,7 +228,11 @@
         const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
         const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
           for (const val of values) {
-              if (val instanceof File) {
+              if (val === undefined) {
+                  continue;
+              } else if (val === null) {
+                  formData.append(key, '');
+              } else if (val instanceof File) {
                   formData.append(key, val);
               } else if (typeof val === 'object' && val !== null) {
                   formData.append(key, JSON.stringify(val));

--- a/apps/cli/src/tests/__snapshots__/generate_swagger_2_0_cookies.ts
+++ b/apps/cli/src/tests/__snapshots__/generate_swagger_2_0_cookies.ts
@@ -222,16 +222,20 @@
     //multipart/form-data
     const formData = new FormData();
   
-    if (requestContract) {
+     if (requestContract) {
       Object.keys(requestContract).forEach(key => {
         const value = requestContract[key as keyof Type];
-        if (value instanceof File) {
-          formData.append(key, value);
-        } else if (typeof value === 'object' && value !== null) {
-          formData.append(key, JSON.stringify(value));
-        } else {
-          formData.append(key, value as any);
-        }
+        const isKeyArrayAndValueIterable = key.endsWith('[]') && typeof (value as any)[Symbol.iterator] === 'function';
+        const values = isKeyArrayAndValueIterable ? Array.from(value as Iterable<any>) : [value];
+          for (const val of values) {
+              if (val instanceof File) {
+                  formData.append(key, val);
+              } else if (typeof val === 'object' && val !== null) {
+                  formData.append(key, JSON.stringify(val));
+              } else {
+                  formData.append(key, val as any);
+              }
+          }
       });
     }
   

--- a/apps/cli/src/tests/fixtures/multipart_formdata_multiplefiles.json
+++ b/apps/cli/src/tests/fixtures/multipart_formdata_multiplefiles.json
@@ -1,0 +1,201 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Test multipart multiple",
+    "description": "Multipart",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "\/api\/electronic-trade\/trades\/{electronicTradeId}\/formality": {
+      "post": {
+        "description": "Adds formality to the electronic trade",
+        "operationId": "0e7b56ecc821c0858df164f848f6aea2",
+        "parameters": [
+          {
+            "name": "electronicTradeId",
+            "in": "path",
+            "description": "Electronic trade id",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Specify returned fields (data.id,id,data.client.name,contract.number, ...etc)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart\/form-data": {
+              "schema": {
+                "$ref": "#\/components\/schemas\/ElectronicTradeFormalityRequestDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Added successfully."
+          }
+        }
+      }
+    }
+
+  },
+  "components": {
+    "schemas": {
+      "ElectronicTradeFormalityEnum": {
+        "type": "string",
+        "enum": [
+          "BlueAgreement",
+          "AML",
+          "Termination",
+          "TransferUnderSAB",
+          "Change",
+          "LoanProtocolHandover",
+          "TradeProducerProtocol",
+          "Modelation",
+          "Other",
+          "ZZJ",
+          "TradeIdentificationForm",
+          "NewInstruction",
+          "LoanRequest",
+          "ESIP",
+          "Contract"
+        ]
+      },
+      "ErrorDetailDTO": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "example": "string"
+          },
+          "message": {
+            "type": "string",
+            "example": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ExceptionDTO": {
+        "properties": {
+          "errors": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#\/components\/schemas\/ErrorDetailDTO"
+              }
+            }
+          },
+          "type": {
+            "type": "string",
+            "example": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "example": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "example": 0,
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "example": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "example": "string",
+            "nullable": true
+          },
+          "stackTrace": {
+            "description": "Only available in development mode.",
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#\/components\/schemas\/ExceptionStackTraceItemDTO"
+              }
+            }
+          }
+        },
+        "type": "object"
+      },
+      "ExceptionStackTraceItemDTO": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "example": "string",
+            "nullable": true
+          },
+          "line": {
+            "type": "integer",
+            "example": "string",
+            "nullable": true
+          },
+          "function": {
+            "type": "string",
+            "example": "string",
+            "nullable": true
+          },
+          "class": {
+            "type": "string",
+            "example": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "example": "string",
+            "nullable": true
+          }
+        },
+        "type": "object"
+      },
+      "ElectronicTradeFormalityDataRequestDTO": {
+        "properties": {
+          "formalityType": {
+            "$ref": "#\/components\/schemas\/ElectronicTradeFormalityEnum"
+          },
+          "sendByPostOffice": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "targetRelationId": {
+            "type": "integer",
+            "nullable": true
+          }
+        },
+        "type": "object"
+      },
+      "ElectronicTradeFormalityRequestDTO": {
+        "properties": {
+          "data": {
+            "$ref": "#\/components\/schemas\/ElectronicTradeFormalityDataRequestDTO"
+          },
+          "files[]": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "tags": []
+}

--- a/apps/cli/src/tests/generate.test.ts
+++ b/apps/cli/src/tests/generate.test.ts
@@ -13,6 +13,7 @@ const cases = [
   "post_put_bodies",
   "swagger_2_0",
   "multipart_formdata",
+  "multipart_formdata_multiplefiles",
 ];
 
 function fixturePath(name: string) {


### PR DESCRIPTION
Hi @gaboe 

I have added few enhancements for multipart/form-data support.

1. Added support for [] in keyName
From:
![image](https://github.com/gaboe/rest2ts/assets/10745725/f73a2254-6650-411c-8a1a-a3bd8adcb483)
To:
![image](https://github.com/gaboe/rest2ts/assets/10745725/14553f4b-a6d3-48da-9595-b5ef2e605d09)

2. For multipart formdata - update formData according to new rules:

- Added check if value is iterable and keyName ends with []
- if value is undefined => do not send through formdata (because formdata sends it as string "undefined")
- if value is null => send empty string (because formdata sends null as string "null")
![image](https://github.com/gaboe/rest2ts/assets/10745725/af5c4d83-678c-412c-b3ad-16ff93f92347)


Result:
postRequest:
![image](https://github.com/gaboe/rest2ts/assets/10745725/2ef36bda-f701-4655-9df7-ee6e38a44cc3)
will send it like this:
<img width="214" alt="image" src="https://github.com/gaboe/rest2ts/assets/10745725/7ee92ef1-a5e7-47fe-a199-6c31163a472c">



